### PR TITLE
Line Widths With No Axis Fix

### DIFF
--- a/mplbasketball/court.py
+++ b/mplbasketball/court.py
@@ -18,7 +18,7 @@ class LineDataUnits(lines.Line2D):
             trans = self.axes.transData.transform
             return ((trans((1, self._lw_data)) - trans((0, 0))) * ppd)[1]
         else:
-            return 1
+            return self._lw_data
 
     def _set_lw(self, lw):
         self._lw_data = lw
@@ -40,7 +40,7 @@ class PatchDataUnits(patches.PathPatch):
             # the line mentioned below
             return ((trans((self._lw_data, self._lw_data)) - trans((0, 0))) * ppd)[1]
         else:
-            return 1
+            return self._lw_data
 
     def _set_lw(self, lw):
         self._lw_data = lw


### PR DESCRIPTION
This was a really quick fix that helps out biomechanical visualizations with `pyglet`. This is a two line alteration to the `PatchDataUnits` and `LineDataUnits` objects in `mplbasketball`, which have a step where they calculate the line width in pixels that corresponds to a specific width on the court. Those lines are:

```python
def _get_lw(self):
        if self.axes is not None:
            ppd = 72.0 / self.axes.figure.dpi
            trans = self.axes.transData.transform
            # the line mentioned below
            return ((trans((self._lw_data, self._lw_data)) - trans((0, 0))) * ppd)[1]
        else:
            return 1
```

That second condition is rarely ever triggered with a typical `matplotlib` call, but it does get called when the `pyglet-branch` uses `mplbasketball`, causing it to always draw lines that are 1 unit thick. The quick change is the following:'

```python
def _get_lw(self):
        if self.axes is not None:
            ppd = 72.0 / self.axes.figure.dpi
            trans = self.axes.transData.transform
            # the line mentioned below
            return ((trans((self._lw_data, self._lw_data)) - trans((0, 0))) * ppd)[1]
        else:
            return self._lw_data
```

Which means that instead of returning 1 for the line thickness when there are no axes in the object, it will return whatever the line width was set to be.
