### PR TITLE
feat: add support for hoop origin

### DIFF
--- a/mplbasketball/court.py
+++ b/mplbasketball/court.py
@@ -82,6 +82,7 @@ class Court:
             "bottom-left",
             "top-right",
             "bottom-right",
+            "hoop"
         ], "Invalid origin. Choose from 'center', '(top/bottom)-(left/right)'"
         assert units in ["m", "ft"], "Invalid units. Currently only 'm' and 'ft' are supported"
 
@@ -119,6 +120,12 @@ class Court:
                     -self.court_parameters["court_dims"][1] / 2,
                 ]
             )
+        elif origin == "hoop":
+            self.origin = np.array([
+                (self.court_parameters['court_dims'][0] / 2) - 
+                 self.court_parameters['hoop_distance_from_edge'],
+                0.0
+            ])
 
     def draw(
         self,

--- a/mplbasketball/utils.py
+++ b/mplbasketball/utils.py
@@ -1,4 +1,4 @@
-def transform(x, y, fr, to, origin, court_dims=[94.0, 50.0]):
+def transform(x, y, fr, to, origin, court_parameters):
     """
     Function to transform a set of x, y values to match orientations desired for plotting.
 
@@ -28,13 +28,18 @@ def transform(x, y, fr, to, origin, court_dims=[94.0, 50.0]):
     if origin == "center":
         center_court = [0.0, 0.0]
     elif origin == "top-left":
-        center_court = [court_dims[0] / 2, -court_dims[1] / 2]
+        center_court = [court_parameters['court_dims'][0] / 2, -court_parameters['court_dims'][1] / 2]
     elif origin == "bottom-left":
-        center_court = [court_dims[0] / 2, court_dims[1] / 2]
+        center_court = [court_parameters['court_dims'][0] / 2, court_parameters['court_dims'][1] / 2]
     elif origin == "top-right":
-        center_court = [-court_dims[0] / 2, -court_dims[1] / 2]
+        center_court = [-court_parameters['court_dims'][0] / 2, -court_parameters['court_dims'][1] / 2]
     elif origin == "bottom-right":
-        center_court = [-court_dims[0] / 2, court_dims[1] / 2]
+        center_court = [-court_parameters['court_dims'][0] / 2, court_parameters['court_dims'][1] / 2]
+    elif origin == "hoop":
+        center_court = [
+            - (court_parameters['court_dims'][0] / 2) + court_parameters['hoop_distance_from_edge'],  
+            0.0  
+        ]
 
     if fr == to:
         return x, y


### PR DESCRIPTION
The hoop origin draws the data at "vu".
```python
court = Court(court_type="nba", origin="hoop", units="ft")
_, ax = court.draw(orientation='v', showaxis=True)
```
![image](https://github.com/user-attachments/assets/14180bef-f5ab-42e9-8524-8e034a91e0a7)

Use the updated transform function to move the coordinates elsewhere:

```python
shot_data['X'], shot_data['Y'] = transform(shot_data['X'], shot_data['Y'], 'v', 'hl', 'hoop', court.court_parameters)
 _, ax = court.draw(orientation='hl', showaxis=True)
 ```
![image](https://github.com/user-attachments/assets/9dea8204-3a8f-4fc4-b27e-f5d7d3a7ff1e)
